### PR TITLE
Update Audi A7: Add Wikipedia references and standard README template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Audi A7
 
+This repository contains signal set configurations for the Audi A7, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Audi A7.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Audi_A7"
+
 generations:
   - name: "First Generation (4G)"
     start_year: 2010


### PR DESCRIPTION
- Added: Wikipedia reference to generations.yaml
- Updated: README.md with standard template
- Verified: Generation years correct per Wikipedia (no corrections needed)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
